### PR TITLE
Really support PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": "~7.0|~8.0",
         "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|~6.0|^7.0|^8.0",
         "illuminate/http": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|~6.0|^7.0|^8.0",
-        "mtownsend/xml-to-array": "^1.0"
+        "mtownsend/xml-to-array": "^1.0|^2.0"
     },
     "require-dev": {
       "phpunit/phpunit": "^6.4|^8.5"


### PR DESCRIPTION
Library says it supports PHP 8 but it doesnt because xml-to-array doesnt support php8 unless its 2.0

See #3 & #4