### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/Providers/RequestXmlServiceProvider.php
+++ b/src/Providers/RequestXmlServiceProvider.php
@@ -53,7 +53,7 @@ class RequestXmlServiceProvider extends ServiceProvider
     protected function registerIsXml()
     {
         Request::macro('isXml', function () {
-            return Str::contains(strtolower($this->getContentType()), 'xml');
+            return Str::contains(strtolower($this->getContentType() ?? ''), 'xml');
         });
     }
 


### PR DESCRIPTION
strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/mtownsend/request-xml/src/Providers/RequestXmlServiceProvider.php on line 56