### PR TITLE
Update Removed getContentType with getContentTypeFormat

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,22 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="MyPackage Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	bootstrap="vendor/autoload.php"
+	backupGlobals="false"
+	colors="true"
+	processIsolation="false"
+	stopOnFailure="false"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+	cacheDirectory=".phpunit.cache"
+	backupStaticProperties="false">
+	<testsuites>
+		<testsuite name="MyPackage Test Suite">
+			<directory>tests</directory>
+		</testsuite>
+	</testsuites>
+	<source>
+		<include>
+			<directory suffix=".php">src/</directory>
+		</include>
+	</source>
 </phpunit>

--- a/src/Providers/RequestXmlServiceProvider.php
+++ b/src/Providers/RequestXmlServiceProvider.php
@@ -53,6 +53,10 @@ class RequestXmlServiceProvider extends ServiceProvider
     protected function registerIsXml()
     {
         Request::macro('isXml', function () {
+            if (method_exists($this, 'getContentType')) {
+                return Str::contains(strtolower($this->getContentType() ?? ''), 'xml');
+            }
+
             return Str::contains(strtolower($this->getContentTypeFormat() ?? ''), 'xml');
         });
     }

--- a/src/Providers/RequestXmlServiceProvider.php
+++ b/src/Providers/RequestXmlServiceProvider.php
@@ -53,7 +53,7 @@ class RequestXmlServiceProvider extends ServiceProvider
     protected function registerIsXml()
     {
         Request::macro('isXml', function () {
-            return Str::contains(strtolower($this->getContentType() ?? ''), 'xml');
+            return Str::contains(strtolower($this->getContentTypeFormat() ?? ''), 'xml');
         });
     }
 

--- a/tests/RequestXmlTest.php
+++ b/tests/RequestXmlTest.php
@@ -5,7 +5,7 @@ use Mtownsend\RequestXml\Providers\RequestXmlServiceProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass as Reflect;
 
-class RequestXml extends TestCase
+class RequestXmlTest extends TestCase
 {
 
     /** @test array */


### PR DESCRIPTION
The `getContentType` method is removed from their changelog on version 7. Use `getContentTypeFormat` instead.
 
All tests are now passed.

Closes #12 