### PR TITLE
fix value error when request payload is empty, but content type is xml

### DIFF
--- a/src/Providers/RequestXmlServiceProvider.php
+++ b/src/Providers/RequestXmlServiceProvider.php
@@ -69,7 +69,7 @@ class RequestXmlServiceProvider extends ServiceProvider
     protected function registerXml()
     {
         Request::macro('xml', function () {
-            if (!$this->isXml() or empty($this->getContent())) {
+            if (!$this->isXml() || empty($this->getContent())) {
                 return [];
             }
             try {

--- a/src/Providers/RequestXmlServiceProvider.php
+++ b/src/Providers/RequestXmlServiceProvider.php
@@ -69,7 +69,7 @@ class RequestXmlServiceProvider extends ServiceProvider
     protected function registerXml()
     {
         Request::macro('xml', function () {
-            if (!$this->isXml()) {
+            if (!$this->isXml() or empty($this->getContent())) {
                 return [];
             }
             try {

--- a/tests/RequestXmlTest.php
+++ b/tests/RequestXmlTest.php
@@ -83,4 +83,12 @@ class RequestXmlTest extends TestCase
         $request = $this->createDummyRequest(['CONTENT_TYPE' => 'application/xml'], $this->testXml);
         $this->assertEquals($request->xml(), $this->testArray);
     }
+
+    /** @test */
+    public function request_with_xml_content_type_and_empty_payload()
+    {
+        $request = $this->createDummyRequest(['CONTENT_TYPE' => 'application/xml']);
+        $this->assertEquals($request->xml(), []);
+        $this->assertTrue($request->isXml());
+    }
 }


### PR DESCRIPTION
Hi there, im trying to use your package, and noticed that if an xml request with an empty payload is sent, a value error is thrown.

```
ValueError: DOMDocument::loadXML(): Argument #1 ($source) must not be empty
```

this change will check if the request content is empty, and if so return an empty array (in the same manner a non xml request does).
im not sure if you still want to consider a request with an empty body as XML for isXml() or not, but for now i assume you still do based on the content type